### PR TITLE
using v2 css as support for katapod 1.2.1 pre-release

### DIFF
--- a/css/katapodv2.css
+++ b/css/katapodv2.css
@@ -428,14 +428,15 @@ summary {
   display: block;
 }*/
 
-pre code.executable {
+pre.executable {
   cursor: pointer;
   background-color: lightgray;
 }
-pre code.nonexecutable {
+pre.nonexecutable {
   cursor: default;
   background-color: #B0CFFF;
 }
+
 a.codeblock {
   text-decoration: none;
 }


### PR DESCRIPTION
i.e. there are necessary css changes to address horiz scrolling codeblocks.
Since v2 is not used by main katapod anymore we use v2 as support for a pre-release of 1.2.1.

See https://github.com/DataStax-Academy/katapod/pull/5.